### PR TITLE
Feature/eslint style rules

### DIFF
--- a/.github/linters/.eslintrc.yml
+++ b/.github/linters/.eslintrc.yml
@@ -40,3 +40,8 @@ rules:
   cypress/no-unnecessary-waiting: "off"
   no-unused-vars: "warn"
   no-fallthrough: "warn"
+  no-var: "error"
+  indent: "warn"
+  max-len: ["warn", { "code": 100, "tabWidth": 4 }]
+  id-length: ["warn", { "min": 3 }]
+  camelcase: ["warn", { allow: ["^._"]}] # ignore variables that start with a single letter and an underscore, i.e o_btn


### PR DESCRIPTION
Set eslint rules to enforce style rules, currently giving warnings so that team can check linting on the local end without breaking workflows.