### PR TITLE
Add drag-and-drop support for mobile and Safari

### DIFF
--- a/source/v1/css/layout.css
+++ b/source/v1/css/layout.css
@@ -203,6 +203,7 @@ body {
   background-color: green;
   padding: 10px 0;
   margin: 15px 0;
+  width: 90%; /* So you can still scroll within sidebar*/
 }
 
 /**
@@ -213,9 +214,9 @@ body {
 }
 
 /**
- * Class for when dragging/moving an task
+ * Class to indicate dragging/moving an task
  */
-.dragging {
+task-item[dragging=""] > div {
   opacity: 0.5;
 }
 

--- a/source/v1/cypress_tests/cypress/integration/tests/taskListTests.js
+++ b/source/v1/cypress_tests/cypress/integration/tests/taskListTests.js
@@ -167,7 +167,7 @@ describe("Task List Tests", () => {
         });
 
         // pick up Task1 and drop in between Task2 and Task3
-        cy.get("task-item[taskid='0'] > div").drag("task-item[taskid='2'] > div", {
+        cy.get("task-item[taskid='0']").drag("task-item[taskid='2']", {
             target: { x: 0, y: 0 }, // applies to the drop target
             force: true, // applied to both the source and target element
         }).then((success) => {
@@ -194,7 +194,7 @@ describe("Task List Tests", () => {
         cy.wait(1000);
 
         // pick up Task1 and drop after Task3
-        cy.get("task-item[taskid='1'] > div").drag("task-item[taskid='2'] > div", {
+        cy.get("task-item[taskid='1']").drag("task-item[taskid='2']", {
             target: { x: 0, y: 100 }, // applies to the drop target
             force: true, // applied to both the source and target element
         }).then((success) => {

--- a/source/v1/cypress_tests/cypress/integration/tests/taskListTests.js
+++ b/source/v1/cypress_tests/cypress/integration/tests/taskListTests.js
@@ -167,7 +167,7 @@ describe("Task List Tests", () => {
         });
 
         // pick up Task1 and drop in between Task2 and Task3
-        cy.get("task-item[taskid='0']").drag("task-item[taskid='2']", {
+        cy.get("task-item[taskid='0'] > div").drag("task-item[taskid='2'] > div", {
             target: { x: 0, y: 0 }, // applies to the drop target
             force: true, // applied to both the source and target element
         }).then((success) => {
@@ -194,7 +194,7 @@ describe("Task List Tests", () => {
         cy.wait(1000);
 
         // pick up Task1 and drop after Task3
-        cy.get("task-item[taskid='1']").drag("task-item[taskid='2']", {
+        cy.get("task-item[taskid='1'] > div").drag("task-item[taskid='2'] > div", {
             target: { x: 0, y: 100 }, // applies to the drop target
             force: true, // applied to both the source and target element
         }).then((success) => {

--- a/source/v1/js/task.js
+++ b/source/v1/js/task.js
@@ -28,6 +28,9 @@ class Task extends HTMLElement {
         this.addEventListener('dragstart', () => {
            this.classList.add('dragging');
         });
+        this.addEventListener('touchstart', () => {
+            this.classList.add('dragging');
+        })
 
         let o_div = document.createElement("div");
         o_div.id = "wrap-task";
@@ -125,6 +128,7 @@ class Task extends HTMLElement {
      */
     bindHandleDragend(f_dragend_action) {
         this.addEventListener("dragend", f_dragend_action);
+        this.addEventListener("touchend", f_dragend_action);
     }
 
 }

--- a/source/v1/js/task.js
+++ b/source/v1/js/task.js
@@ -31,7 +31,7 @@ class Task extends HTMLElement {
         o_div.setAttribute("draggable", true);
         o_div.classList.add("draggable");
         // event listener to tell when this task is being dragged 
-        o_div.addEventListener('dragstart', () => {
+        this.addEventListener('dragstart', () => {
            this.setAttribute("dragging", "");
         });
         o_div.addEventListener('touchstart', () => {
@@ -131,7 +131,7 @@ class Task extends HTMLElement {
      */
     bindHandleDragend(f_dragend_action) {
         const o_div = this.querySelector("#wrap-task");
-        o_div.addEventListener("dragend", f_dragend_action);
+        this.addEventListener("dragend", f_dragend_action);
         o_div.addEventListener("touchend", f_dragend_action);
     }
 

--- a/source/v1/js/task.js
+++ b/source/v1/js/task.js
@@ -20,20 +20,23 @@ class Task extends HTMLElement {
         // reference to these functions so we can remove the event listeners
         this.f_delete_action = null;
         this.f_edit_action = null;
-        
-        // set dragging class/attribute
-        this.setAttribute("draggable", true);
-        this.classList.add("draggable");
-        // event listener to tell when this task is being dragged 
-        this.addEventListener('dragstart', () => {
-           this.classList.add('dragging');
-        });
-        this.addEventListener('touchstart', () => {
-            this.classList.add('dragging');
-        })
 
         let o_div = document.createElement("div");
         o_div.id = "wrap-task";
+
+        // MUST SET draggable attr and eventListeners on o_div to work on 
+        // Safari; something weird with unable to set stuff directly on web components
+
+        // set dragging class/attribute
+        o_div.setAttribute("draggable", true);
+        o_div.classList.add("draggable");
+        // event listener to tell when this task is being dragged 
+        o_div.addEventListener('dragstart', () => {
+           this.setAttribute("dragging", "");
+        });
+        o_div.addEventListener('touchstart', () => {
+           this.setAttribute("dragging", "");
+        })
 
         let o_item = document.createElement("input");
         o_item.title = "Click to Edit";
@@ -127,8 +130,20 @@ class Task extends HTMLElement {
      * @param {Function}  f_dragend_action function that handles dragover
      */
     bindHandleDragend(f_dragend_action) {
-        this.addEventListener("dragend", f_dragend_action);
-        this.addEventListener("touchend", f_dragend_action);
+        const o_div = this.querySelector("#wrap-task");
+        o_div.addEventListener("dragend", f_dragend_action);
+        o_div.addEventListener("touchend", f_dragend_action);
+    }
+
+    /**
+     * Binds touchmove handler to the task-item. Enables drag and drop for 
+     * touch-enabled devices, such as mobile. Needs a bind in order to 
+     * differentiate scrolling and moving around tasks.
+     * @param {Function} f_touchmove_action 
+     */
+    bindHandleTouchMove(f_touchmove_action) {
+        const o_div = this.querySelector("#wrap-task");
+        o_div.addEventListener('touchmove', f_touchmove_action);
     }
 
 }

--- a/source/v1/js/taskList.js
+++ b/source/v1/js/taskList.js
@@ -139,7 +139,8 @@ class TaskList extends HTMLElement {
         o_event.preventDefault();
         // get task that is directly after the position of current task
         // that is being dragged
-        const o_after_task = this.getDragAfterElement(o_event.clientY) || this.getDragAfterElement(o_event.targetTouches[0].pageY);
+        const n_y_coord = o_event.clientY != null ? o_event.clientY : o_event.targetTouches[0].pageY;
+        const o_after_task = this.getDragAfterElement(n_y_coord); 
         // get current element being dragged
         const o_dragged_task = document.querySelector('.dragging');
         // ensure there is a dragged task

--- a/source/v1/js/taskList.js
+++ b/source/v1/js/taskList.js
@@ -106,6 +106,7 @@ class TaskList extends HTMLElement {
         o_tasks.id = "all-tasks";
         // handles reordering task items visually in HTML
         o_tasks.addEventListener('dragover', (e) => this.handleDrag(o_tasks, e));
+        o_tasks.addEventListener('touchmove', (e) => this.handleDrag(o_tasks, e));
 
         o_wrapper_obj.append(o_close_button, o_task_title_wrapper, o_tasks);
         this.append(o_wrapper_obj_back);
@@ -138,7 +139,7 @@ class TaskList extends HTMLElement {
         o_event.preventDefault();
         // get task that is directly after the position of current task
         // that is being dragged
-        const o_after_task = this.getDragAfterElement(o_event.clientY);
+        const o_after_task = this.getDragAfterElement(o_event.clientY) || this.getDragAfterElement(o_event.targetTouches[0].pageY);
         // get current element being dragged
         const o_dragged_task = document.querySelector('.dragging');
         // ensure there is a dragged task

--- a/source/v1/js/taskList.js
+++ b/source/v1/js/taskList.js
@@ -104,9 +104,8 @@ class TaskList extends HTMLElement {
         let o_tasks = document.createElement("div");
         o_tasks.className = "hidden";
         o_tasks.id = "all-tasks";
-        // handles reordering task items visually in HTML
-        o_tasks.addEventListener('dragover', (e) => this.handleDrag(o_tasks, e));
-        o_tasks.addEventListener('touchmove', (e) => this.handleDrag(o_tasks, e));
+        // handles reordering task items visually in HTML for desktop
+        o_tasks.addEventListener('dragover', (e) => this.handleDrag(e));
 
         o_wrapper_obj.append(o_close_button, o_task_title_wrapper, o_tasks);
         this.append(o_wrapper_obj_back);
@@ -132,21 +131,23 @@ class TaskList extends HTMLElement {
     /**
      * Handles setting the order of tasks (in HTML) after being dragged to 
      * desired spot
-     * @param {Object} o_tasks_container container that holds all tasks created
      * @param {Event} o_event window event that has occurred
      */
-    handleDrag(o_tasks_container, o_event) {
+    handleDrag(o_event) {
         o_event.preventDefault();
+        // y-coordinate is either from desktop or from mobile
+        const n_y_coord = o_event.clientY != null ? o_event.clientY : o_event.targetTouches[0].pageY;
         // get task that is directly after the position of current task
         // that is being dragged
-        const n_y_coord = o_event.clientY != null ? o_event.clientY : o_event.targetTouches[0].pageY;
         const o_after_task = this.getDragAfterElement(n_y_coord); 
         // get current element being dragged
-        const o_dragged_task = document.querySelector('.dragging');
+        const o_dragged_task = this.querySelector('task-item[dragging=""]');
         // ensure there is a dragged task
         if (o_dragged_task == null) {
             return;
         }
+        // add appropriately to tasklist
+        const o_tasks_container = this.querySelector('#all-tasks');
         // dragging task to end of list
         if (o_after_task == null) {
             o_tasks_container.appendChild(o_dragged_task);
@@ -165,7 +166,8 @@ class TaskList extends HTMLElement {
      */
     getDragAfterElement(n_y_coord) {
         // get all tasks except the one that is dragging
-        const o_undragged_tasks = [...this.querySelectorAll('.draggable:not(.dragging)')]
+        const o_undragged_tasks = [...this.querySelectorAll('task-item:not([dragging=""]')]
+        // console.log(o_undragged_tasks);
         return o_undragged_tasks.reduce((closest, curTask) => {
             const box = curTask.getBoundingClientRect();
             const offset = n_y_coord - box.top - box.height / 2;
@@ -254,9 +256,10 @@ class TaskList extends HTMLElement {
         o_task.setAttribute("taskname", s_task_name);
         o_task.setAttribute("taskid", n_task_id);
         o_task.bindHandleDelete(() => { this.removeItem(n_task_id); });
+        // bind a function that listen to an onchange for a task input element
         o_task.bindHandleEdit(() => { this.editItemName(n_task_id); });
         o_task.bindHandleDragend(() => { this.setNewTaskOrder(o_task); });
-        // bind a function that listen to an onchange for a task input element
+        o_task.bindHandleTouchMove((e) => this.handleDrag(e));
 
         this.querySelector("#all-tasks").append(o_task);
 
@@ -354,8 +357,9 @@ class TaskList extends HTMLElement {
      * @param {Object} o_task task HTML object to remove the dragging class from
      */
     setNewTaskOrder(o_task) {
-        // remove draggable class on current dragging object
-        o_task.classList.remove('dragging');
+        // remove dragging attribute on currently dragging object
+        o_task.removeAttribute("dragging");
+        console.log(o_task.children[0]);
         // update this.o_tasks
         const n_num_tasks = this.getNumTasks();
         const o_task_items = document.getElementById('all-tasks').children;
@@ -411,9 +415,10 @@ class TaskList extends HTMLElement {
                     o_task.setAttribute("taskid", i);
                     console.log(this.n_task_id);
                     o_task.bindHandleDelete(() => { this.removeItem(i); });
+                    // bind a function that listen to an onchange for a task input element
                     o_task.bindHandleEdit(() => { this.editItemName(i); });
                     o_task.bindHandleDragend(() => { this.setNewTaskOrder(o_task); })
-                    // bind a function that listen to an onchange for a task input element
+                    o_task.bindHandleTouchMove((e) => this.handleDrag(e));
                     this.n_next_task_id++;
                     this.querySelector("#all-tasks").append(o_task);
                 }


### PR DESCRIPTION
## Changes to Add Mobile Support
- Mobile did not support the drag events that we had previously implemented in Sprint 2 (`dragstart`, `dragover`, and `dragend`), so we added more event listeners for touch events: `touchstart`, `touchmove`, and `touchend`.
- Since the functionality is the same, we just used the same existing functions for the touch events.
- The only change was in `handleDrag`, where there was a different variable to get the y-coordinates (`o_event.targetTouches[0].pageY`)
- Reduced width of a task in the sidebar so that you are still able to scroll and move around tasks. It's a bit finicky with the UI still, since on mobile, everything is dependent on touch events.

## Changes to Fix Safari (and Mobile)
- We moved the draggable attribute from the web component's wrapper (`task-item`) to the `div` inside it. I think Safari was not applying styles or attributes when we set stuff on the `task-item` tag, so this was the solution.

Closes #56 