### PR TITLE
Feature/add safari error notifi checkbox

### DIFF
--- a/source/v1/css/layout.css
+++ b/source/v1/css/layout.css
@@ -434,8 +434,6 @@ input[type=text] {
 .centered-note footer {
   margin: 0.8rem;
 }
-
-
 /**************************
  * Styling Pomodoro Timer *
  **************************/

--- a/source/v1/js/notify.js
+++ b/source/v1/js/notify.js
@@ -49,18 +49,17 @@ function notify(n_state){
                             // Auto-play was prevented
                             // Show a UI element to let the user manually start playback
                             const b_showErrorNotification = localStorage.getItem("safari-error-notification");
-                            console.log("catch error kjdshfkja" + b_showErrorNotification);
+                            const b_showErrorNotification_preference = localStorage.getItem("safari-error-notification-preference");
 
                             if (b_showErrorNotification == null || b_showErrorNotification == false || 
-                                b_showErrorNotification == "false") {
+                                b_showErrorNotification == "false" || b_showErrorNotification_preference == "true" || b_showErrorNotification_preference == true) {
                                 // show error notification view
                                 let o_notifi = document.querySelector("notification-box");
                                 o_notifi.showNotificationBox();
-                                localStorage.setItem("safari-error-notification", true)
-                            }
+                                localStorage.setItem("safari-error-notification", "true")
+                            } 
                         }).then(() => {
                             // Auto-play started successfully
-                            console.log("kjdshfkja");
                         });
                     }
 

--- a/source/v1/js/notify.js
+++ b/source/v1/js/notify.js
@@ -51,8 +51,7 @@ function notify(n_state){
                             const b_showErrorNotification = localStorage.getItem("safari-error-notification");
                             const b_showErrorNotification_preference = localStorage.getItem("safari-error-notification-preference");
 
-                            if (b_showErrorNotification == null || b_showErrorNotification == false || 
-                                b_showErrorNotification == "false" || b_showErrorNotification_preference == "true" || b_showErrorNotification_preference == true) {
+                            if (b_showErrorNotification === null || b_showErrorNotification === "false" || b_showErrorNotification_preference === "true") {
                                 // show error notification view
                                 let o_notifi = document.querySelector("notification-box");
                                 o_notifi.showNotificationBox();

--- a/source/v1/js/settingsTab.js
+++ b/source/v1/js/settingsTab.js
@@ -131,7 +131,7 @@ class SettingsTab extends HTMLElement {
 
         o_setting_three_buttons.append(o_setting_three_btn_one, o_setting_three_btn_two, o_setting_three_btn_three);
         o_setting_three_wrapper.append(o_setting_three_title, o_setting_three_buttons);
-        
+
 
         // Bottom note to explain settings
         let o_bottom_wrapper = document.createElement("div");
@@ -145,6 +145,25 @@ class SettingsTab extends HTMLElement {
 
         // Add each setting to settings wrapper
         o_all_settings_wrapper.append(o_setting_one_wrapper, o_setting_two_wrapper, o_setting_three_wrapper, o_bottom_wrapper);
+      
+        let b_isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(navigator.userAgent);
+
+        if (b_isSafari) {
+             // add safari error notification check box 
+          let o_safari_check_box = document.createElement("input");
+          o_safari_check_box.classList.add("error-check-box");
+          o_safari_check_box.id = "safari-check-box";
+          o_safari_check_box.setAttribute("type", "checkbox");
+
+          let o_safari_check_box_label = document.createElement("label");
+          o_safari_check_box_label.id = "safari-check-box-label";
+          o_safari_check_box_label.innerHTML = "Enable Error Notification";
+
+          // append safari check box
+          o_all_settings_wrapper.append(o_safari_check_box);
+          o_all_settings_wrapper.append(o_safari_check_box_label);
+        }
+
 
         o_settings_title_wrapper.append(o_close_button, o_settings_title);
         o_wrapper_obj.append(o_settings_title_wrapper, o_all_settings_wrapper);

--- a/source/v1/js/settingsTab.js
+++ b/source/v1/js/settingsTab.js
@@ -159,6 +159,7 @@ class SettingsTab extends HTMLElement {
             o_safari_check_box.checked = false;
           } else {
             o_safari_check_box.checked = true;
+            localStorage.setItem("safari-error-notification-preference", "true");
           }
 
           o_safari_check_box.addEventListener('change', (event) => {

--- a/source/v1/js/settingsTab.js
+++ b/source/v1/js/settingsTab.js
@@ -147,13 +147,27 @@ class SettingsTab extends HTMLElement {
         o_all_settings_wrapper.append(o_setting_one_wrapper, o_setting_two_wrapper, o_setting_three_wrapper, o_bottom_wrapper);
       
         let b_isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(navigator.userAgent);
-
         if (b_isSafari) {
              // add safari error notification check box 
           let o_safari_check_box = document.createElement("input");
-          o_safari_check_box.classList.add("error-check-box");
           o_safari_check_box.id = "safari-check-box";
           o_safari_check_box.setAttribute("type", "checkbox");
+
+          const b_showErrorNotification_preference = localStorage.getItem("safari-error-notification-preference");
+
+          if (b_showErrorNotification_preference == "false") {
+            o_safari_check_box.checked = false;
+          } else {
+            o_safari_check_box.checked = true;
+          }
+
+          o_safari_check_box.addEventListener('change', (event) => {
+            if (event.currentTarget.checked) {
+              localStorage.setItem("safari-error-notification-preference", "true");
+            } else {
+              localStorage.setItem("safari-error-notification-preference", "false");
+            }
+          })
 
           let o_safari_check_box_label = document.createElement("label");
           o_safari_check_box_label.id = "safari-check-box-label";
@@ -162,6 +176,7 @@ class SettingsTab extends HTMLElement {
           // append safari check box
           o_all_settings_wrapper.append(o_safari_check_box);
           o_all_settings_wrapper.append(o_safari_check_box_label);
+
         }
 
 


### PR DESCRIPTION
- Add Safari Error Notification CheckBox On Settings
- Only show on Safari
- Local Storage to store user prefernce