### PR TITLE
fix timerContainer.test.js no window.alert and failing promise

### DIFF
--- a/source/v1/jest_tests/timerContainer.test.js
+++ b/source/v1/jest_tests/timerContainer.test.js
@@ -1,6 +1,33 @@
 import { TimerContainer } from "../js/timerContainer.js";
-import { jest } from '@jest/globals';
+import { jest, beforeAll, afterAll } from '@jest/globals';
 import EventBus from "./EventBus.js";
+
+const o_jsdom_notification = window.Notification;
+const f_jsdom_alert = window.alert;
+const p_permission = Promise.resolve("granted");
+const o_audio = document.createElement("audio");
+HTMLAudioElement.prototype.play = jest.fn();
+o_audio.id = "notifs";
+o_audio.src = "assets/audio/notif_tone.mp3";
+
+beforeAll(() => {
+    
+    document.body.appendChild(o_audio);
+    
+    window.alert = jest.fn();
+
+    window.Notification = jest.fn();
+    window.Notification.permission = "default";
+    window.Notification.requestPermission = jest.fn(() => {
+        window.Notification.permission = "granted";
+        return p_permission;
+    });
+});
+
+afterAll(()=>{
+    window.Notification = o_jsdom_notification;
+    window.alert = f_jsdom_alert;        
+});
 
 test("Test getTimeRemaining function", () => {
     document.body.innerHTML = "<timer-element></timer-element>";

--- a/source/v1/js/notify.js
+++ b/source/v1/js/notify.js
@@ -68,11 +68,14 @@ function notify(n_state){
 
                 } else {
                     let o_audio = document.getElementById("notifs");
-                    o_audio.play();
+                    if (o_audio){
+                        o_audio.play();
+                    }
+                    
                 }
                 return o_notification;
             }
-        });
+        }).catch(error => console.error(error));
     }
 }
 


### PR DESCRIPTION
Previously timerContainer.test.js has a soft error that leads to jest log out error in the console. It is due to the window.alert not being implemented. Now it has been fixed.